### PR TITLE
Browsers give an error when specifying content length.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ function xhrJSON(url, options) {
   options.headers['content-type'] = 'application/json'
   if ('data' in options) {
     options.data = Json.stringify(options.data)
-    options.headers['content-length'] = options.data.length
   }
 
   return xhr(url, options).then(parse, parseErr)


### PR DESCRIPTION
Chrome: Refused to set unsafe header "content-length"
